### PR TITLE
relax SDK dependency to allow v5.0

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -7,6 +7,8 @@ publications:
 jobs:
   - template:
       name: php
+      skip:
+        - test  # don't try to run unit tests in the Releaser environment, since they require a database
 
 documentation:
   gitHubPages: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # LaunchDarkly Server-Side SDK for PHP - DynamoDB integration
 
 [![CircleCI](https://circleci.com/gh/launchdarkly/php-server-sdk-dynamodb.svg?style=svg)](https://circleci.com/gh/launchdarkly/php-server-sdk-dynamodb)
+[![Packagist](https://img.shields.io/packagist/v/launchdarkly/server-sdk-dynamodb.svg?style=flat-square)](https://packagist.org/packages/launchdarkly/server-sdk-dynamodb)
+[![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)](https://launchdarkly.github.io/php-server-sdk-dynamodb)
 
 This library provides a DynamoDB-backed data source for the [LaunchDarkly PHP SDK](https://github.com/launchdarkly/php-server-sdk), replacing the default behavior of querying the LaunchDarkly service endpoints. The underlying DynamoDB client implementation is the [AWS SDK for PHP](https://aws.amazon.com/sdk-for-php/).
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.3",
         "aws/aws-sdk-php": "^3.86",
-        "launchdarkly/server-sdk": "^4"
+        "launchdarkly/server-sdk": ">=4.0.0 <6.0.0"
     },
     "require-dev": {
         "launchdarkly/server-sdk-shared-tests": "@dev",


### PR DESCRIPTION
There aren't any relevant internal API differences so the same package will work with both 4.x and 5.0.