### PR TITLE
feat: Allow devs to inject their own `DynamoDbClient` instance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php": ">=7.3",
         "aws/aws-sdk-php": "^3.86",
-        "launchdarkly/server-sdk": ">=4.0.0 <7.0.0"
+        "launchdarkly/server-sdk": ">=4.0.0 <7.0.0",
+        "psr/container": ">=1.1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9"

--- a/src/LaunchDarkly/Integrations/DynamoDb.php
+++ b/src/LaunchDarkly/Integrations/DynamoDb.php
@@ -2,6 +2,7 @@
 namespace LaunchDarkly\Integrations;
 
 use \LaunchDarkly\Impl\Integrations\DynamoDbFeatureRequester;
+use Psr\Container\ContainerInterface;
 
 class DynamoDb
 {
@@ -23,12 +24,17 @@ class DynamoDb
      *   - `dynamodb_prefix`: a string to be prepended to all database keys; corresponds to the prefix
      * setting in ld-relay
      *   - `apc_expiration`: expiration time in seconds for local caching, if `APCu` is installed
-     * @return mixed  an object to be stored in the `feature_requester` configuration property
+     * @return \Closure  an object to be stored in the `feature_requester` configuration property
      */
-    public static function featureRequester(array $options = array())
+    public static function featureRequester(array $options = [], ContainerInterface $container = null)
     {
-        return function ($baseUri, $sdkKey, $baseOptions) use ($options) {
-            return new DynamoDbFeatureRequester($baseUri, $sdkKey, array_merge($baseOptions, $options));
+        return static function ($baseUri, $sdkKey, $baseOptions) use ($options, $container) {
+            return new DynamoDbFeatureRequester(
+                $baseUri,
+                $sdkKey,
+                array_merge($baseOptions, $options),
+                $container
+            );
         };
     }
 }


### PR DESCRIPTION
### Reason for Change

This change promotes the `DynamoDbFeatureRequester` class to be flexible and configurable. The change will allow developers to inject `DynamoDbClient` via `PSR\ContainerInterface` implementation. It will be uniform with modern dependency injection and promote better separation of concerns, making code easier to manage and test.

### Pros

1. **Improved Flexibility**: By allowing the injection of `DynamoDbClient` via a container, developers can easily swap out the client for different implementations or configurations without modifying the core code.
2. **Enhanced Testability**: This change facilitates unit testing by enabling the use of mock or stub implementations of `DynamoDbClient`, leading to more reliable and isolated tests.
3. **Adherence to Best Practices**: Utilizing `PSR\ContainerInterface` for dependency injection is a widely accepted best practice in modern PHP development, promoting consistency and interoperability within the codebase.
4. **Reduced Coupling**: The `DynamoDbFeatureRequester` class becomes less tightly coupled to the specific instantiation details of `DynamoDbClient`, adhering to the Dependency Inversion Principle (DIP) of SOLID design principles.
5. **Configuration Management**: Developers can manage the configuration of `DynamoDbClient` centrally within the container, simplifying the process of updating or changing configurations.

### Cons/Risks

1. **Increased Complexity**: Introducing dependency injection through a container can add a layer of complexity, especially for developers unfamiliar with this pattern.
2. **Potential for Misconfiguration**: If the container is not correctly configured to provide the `DynamoDbClient`, it could lead to runtime errors or unexpected behavior.
3. **Dependency on Container Implementation**: The change introduces a dependency on a `PSR\ContainerInterface` implementation, which may not be present in all environments or projects, requiring additional setup.

### Examples

Before this suggestion, the only allowed way to help devs to reuse their existing `DynamoDbClient` was overwriting the whole `__construct` forcing them to copy-paste it with no `parent::__construct()` call.

---

After this suggestion, the code would look like:

```php
// Backwards compatible code (no changes needed)
$fr = LaunchDarkly\Integrations\DynamoDb::featureRequester([ 'dynamodb_table' => 'my-table' ]);
$config = [ "feature_requester" => $fr ];
$client = new LDClient("sdk_key", $config);
```

```php
// DI definition for a reusable instance
$container->set('DynamoDbClient', static function (ContainerInterface $c) {
    $settings = [ /* Own project settings */ ];
    return new \Aws\DynamoDb\DynamoDbClient($settings);
});

$fr = LaunchDarkly\Integrations\DynamoDb::featureRequester([ 'dynamodb_table' => 'my-table' ], $container);
$config = [ "feature_requester" => $fr ];
$client = new LDClient("sdk_key", $config);
```