### PR TITLE
feat: Add `dynamodb_client` as new option

### DIFF
--- a/src/LaunchDarkly/Impl/Integrations/DynamoDbFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/DynamoDbFeatureRequester.php
@@ -26,11 +26,8 @@ class DynamoDbFeatureRequester extends FeatureRequesterBase
 
         $dynamoDbOptions = $options['dynamodb_options'] ?? [];
         $dynamoDbOptions['version'] = '2012-08-10'; // in the AWS SDK for PHP, this is how you specify the API version
-        $this->_client = $options['dynamodb_client'] ?? new DynamoDbClient($dynamoDbOptions);
-
-        if (!($this->_client instanceof DynamoDbClient)) {
-            throw new \InvalidArgumentException('dynamodb_client must be an instance of Aws\DynamoDb\DynamoDbClient');
-        }
+        $client = $options['dynamodb_client'] ?? null;
+        $this->_client = $client instanceof DynamoDbClient ? $client : new DynamoDbClient($dynamoDbOptions);
 
         $prefix = $options['dynamodb_prefix'] ?? '';
         $this->_prefix = ($prefix != null && $prefix != '') ? ($prefix . ':') : '';

--- a/src/LaunchDarkly/Impl/Integrations/DynamoDbFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/DynamoDbFeatureRequester.php
@@ -28,6 +28,10 @@ class DynamoDbFeatureRequester extends FeatureRequesterBase
         $dynamoDbOptions['version'] = '2012-08-10'; // in the AWS SDK for PHP, this is how you specify the API version
         $this->_client = $options['dynamodb_client'] ?? new DynamoDbClient($dynamoDbOptions);
 
+        if (!($this->_client instanceof DynamoDbClient)) {
+            throw new \InvalidArgumentException('dynamodb_client must be an instance of Aws\DynamoDb\DynamoDbClient');
+        }
+
         $prefix = $options['dynamodb_prefix'] ?? '';
         $this->_prefix = ($prefix != null && $prefix != '') ? ($prefix . ':') : '';
     }

--- a/src/LaunchDarkly/Impl/Integrations/DynamoDbFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/DynamoDbFeatureRequester.php
@@ -26,7 +26,7 @@ class DynamoDbFeatureRequester extends FeatureRequesterBase
 
         $dynamoDbOptions = $options['dynamodb_options'] ?? [];
         $dynamoDbOptions['version'] = '2012-08-10'; // in the AWS SDK for PHP, this is how you specify the API version
-        $this->_client = new DynamoDbClient($dynamoDbOptions);
+        $this->_client = $options['dynamodb_client'] ?? new DynamoDbClient($dynamoDbOptions);
 
         $prefix = $options['dynamodb_prefix'] ?? '';
         $this->_prefix = ($prefix != null && $prefix != '') ? ($prefix . ':') : '';

--- a/src/LaunchDarkly/Integrations/DynamoDb.php
+++ b/src/LaunchDarkly/Integrations/DynamoDb.php
@@ -36,7 +36,7 @@ class DynamoDb
      */
     public static function featureRequester(array $options = [])
     {
-        return static function ($baseUri, $sdkKey, $baseOptions) use ($options) {
+        return function ($baseUri, $sdkKey, $baseOptions) use ($options) {
             return new DynamoDbFeatureRequester($baseUri, $sdkKey, array_merge($baseOptions, $options));
         };
     }

--- a/src/LaunchDarkly/Integrations/DynamoDb.php
+++ b/src/LaunchDarkly/Integrations/DynamoDb.php
@@ -1,7 +1,7 @@
 <?php
 namespace LaunchDarkly\Integrations;
 
-use \LaunchDarkly\Impl\Integrations\DynamoDbFeatureRequester;
+use LaunchDarkly\Impl\Integrations\DynamoDbFeatureRequester;
 
 class DynamoDb
 {
@@ -10,9 +10,16 @@ class DynamoDb
      *
      * After calling this method, store its return value in the `feature_requester` property of your client configuration:
      *
-     *     $fr = LaunchDarkly\Integrations\DynamoDb::featureRequester([ "dynamodb_table" => "my-table" ]);
-     *     $config = [ "feature_requester" => $fr ];
-     *     $client = new LDClient("sdk_key", $config);
+     *     $fr = LaunchDarkly\Integrations\DynamoDb::featureRequester([ 'dynamodb_table' => 'my-table' ]);
+     *     $config = [ 'feature_requester' => $fr ];
+     *     $client = new LDClient('sdk_key', $config);
+     *
+     * Or if you already have a client instance:
+     *
+     *     $dynamoClient = new Aws\DynamoDb\DynamoDbClient($settings);
+     *     $fr = LaunchDarkly\Integrations\DynamoDb::featureRequester([ 'dynamo_client' => $dynamoClient ]);
+     *     $config = [ 'feature_requester' => $fr ];
+     *     $client = new LDClient('sdk_key', $config);
      *
      * For more about using LaunchDarkly with databases, see the
      * [SDK reference guide](https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store).
@@ -22,12 +29,14 @@ class DynamoDb
      *   - `dynamodb_options`: can include any settings supported by the AWS SDK client
      *   - `dynamodb_prefix`: a string to be prepended to all database keys; corresponds to the prefix
      * setting in ld-relay
+     *   - `dynamodb_client`: an already-configured DynamoDb client instance if you wish to reuse one; if
+     * specified, this will cause all other options except `dynamodb_prefix` and `dynamodb_table` to be ignored
      *   - `apc_expiration`: expiration time in seconds for local caching, if `APCu` is installed
-     * @return mixed  an object to be stored in the `feature_requester` configuration property
+     * @return \Closure  an object to be stored in the `feature_requester` configuration property
      */
-    public static function featureRequester(array $options = array())
+    public static function featureRequester(array $options = [])
     {
-        return function ($baseUri, $sdkKey, $baseOptions) use ($options) {
+        return static function ($baseUri, $sdkKey, $baseOptions) use ($options) {
             return new DynamoDbFeatureRequester($baseUri, $sdkKey, array_merge($baseOptions, $options));
         };
     }


### PR DESCRIPTION
Follow up of: https://github.com/launchdarkly/php-server-sdk-dynamodb/pull/19 (Closed)

#### Summary
This PR introduces a new option `dynamodb_client` to the `DynamoDb` integration, allowing developers to reuse an existing `DynamoDbClient` instance. This enhancement provides more flexibility and control over the DynamoDB client configuration.

#### Changes
1. **New Option Added**:
   - `dynamodb_client`: Allows passing an already-configured `DynamoDbClient` instance. If specified, this will cause all other options except `dynamodb_prefix` and `dynamodb_table` to be ignored.

2. **Updated `DynamoDbFeatureRequester` Constructor**:
   - Modified the constructor to accept the `dynamodb_client` option and use it if provided.

3. **Documentation**:
   - Updated the PHPDoc comments in `DynamoDb` to reflect the new option and provide usage examples.

#### Usage
Developers can now configure the `feature_requester` with an existing `DynamoDbClient` instance as shown below:

```php
$dynamoClient = new Aws\DynamoDb\DynamoDbClient($settings);
$fr = LaunchDarkly\Integrations\DynamoDb::featureRequester([ 'dynamo_client' => $dynamoClient ]);
$config = [ 'feature_requester' => $fr ];
$client = new LDClient('sdk_key', $config);
```